### PR TITLE
feat: add products pagination

### DIFF
--- a/clase-2/mango-card/src/App.jsx
+++ b/clase-2/mango-card/src/App.jsx
@@ -7,11 +7,17 @@ import { CATEGORIES } from './consts/categories'
 import { Products } from './components/products'
 import { Filters } from './components/filters'
 import { Cart } from './components/cart'
+import { Pagination } from './components/pagination'
 
 function App() {
   const {
     loading: loadingProducts,
-    products
+    products,
+    page,
+    prevPage,
+    nextPage,
+    limit,
+    total,
   } = useProducts()
 
   const [filterCategory, setFilterCategory] = useState(CATEGORIES[0])
@@ -37,9 +43,25 @@ function App() {
           onChangeCategoryFilter={setFilterCategory} />
       </Header>
 
+      <Pagination
+        page={page}
+        prevPage={prevPage}
+        nextPage={nextPage}
+        limit={limit}
+        total={total}
+      />
+
       <Products
         loadingProducts={loadingProducts}
         products={filteredProducts}
+      />
+
+      <Pagination
+        page={page}
+        prevPage={prevPage}
+        nextPage={nextPage}
+        limit={limit}
+        total={total}
       />
 
       <Cart />

--- a/clase-2/mango-card/src/components/pagination.jsx
+++ b/clase-2/mango-card/src/components/pagination.jsx
@@ -1,0 +1,11 @@
+export function Pagination({ page, prevPage, nextPage, limit, total }) {
+    const totalPages = Math.ceil(total / limit);
+
+    return (
+        <div>
+            <button onClick={prevPage} disabled={page === 0}>Anterior</button>
+            <span>Página {page + 1} de {totalPages}</span>
+            <button onClick={nextPage} disabled={page + 1 >= totalPages}>Siguiente</button>
+        </div>
+    );
+}

--- a/clase-2/mango-card/src/hooks/use-products.jsx
+++ b/clase-2/mango-card/src/hooks/use-products.jsx
@@ -4,12 +4,21 @@ import { useState, useEffect } from 'react'
 export function useProducts() {
   const [products, setProducts] = useState([])
   const [loading, setLoading] = useState(true)
+  const [page, setPage] = useState(0)
+  const [total, setTotal] = useState(0)
+  const limit = 30
 
   useEffect(() => {
-    getProducts()
-      .then(products => setProducts(products))
+    getProducts(limit, page * limit)
+      .then(({products, total}) => {
+        setProducts(products)
+        setTotal(total)
+      })
       .finally(() => setLoading(false))
-  }, [])
+  }, [page]);
 
-  return { loading, products }
+  const nextPage = () => setPage(prevPage => prevPage + 1);
+  const prevPage = () => setPage(prevPage => Math.max(prevPage - 1, 0));
+
+  return { loading, products, nextPage, prevPage, page, limit, total };
 }

--- a/clase-2/mango-card/src/logic/products.js
+++ b/clase-2/mango-card/src/logic/products.js
@@ -1,11 +1,14 @@
-export const getProducts = () => {
-  return fetch('https://dummyjson.com/products')
+export const getProducts = (limit = 30, skip = 0) => {
+  return fetch(`https://dummyjson.com/products?limit=${limit}&skip=${skip}&select=id,title,images,category`)
     .then(res => res.json())
     .then(response => {
-      const { products } = response
-      return products.map(product => {
-        const { id, title, images, category } = product
-        return { id, title, images, category }
-      })
+      const { products, total } = response;
+      return {
+        products: products.map(product => {
+          const { id, title, images, category } = product;
+          return { id, title, images, category };
+        }),
+        total
+      }
     })
 }


### PR DESCRIPTION
## Cambios realizados

1. **Componente `Pagination` creado:**
   - Nuevo componente para navegar entre páginas de productos.
   - Incluye:
     - Botones "Anterior" y "Siguiente".
     - Información del número de página actual y el total de páginas.

2. **Actualización del hook `useProducts`:**
   - Nuevas variables de estado:
     - `page`: Página actual.
     - `total`: Total de productos.
     - `limit`: Número de productos por página (por defecto 30).
   - Métodos añadidos:
     - `nextPage`: Avanza a la siguiente página.
     - `prevPage`: Retrocede a la página anterior.
   - La función `getProducts` ahora acepta parámetros `limit` y `skip` para manejar el paginado en la consulta a la API.

3. **Modificaciones en la función `getProducts`:**
   - Ahora soporta los parámetros `limit` y `skip`.
   - Devuelve el total de productos disponibles junto con los productos paginados.

4. **Integración de la paginación en `App.jsx`:**
   - Añadido el componente `Pagination` antes y después de la lista de productos.
   - Props pasadas desde el hook `useProducts`: `page`, `nextPage`, `prevPage`, `limit`, `total`.
